### PR TITLE
Update docker image so that it includes goreleaser

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 references:
-  circleci-docker-primary: &circleci-docker-primary trussworks/circleci-docker-primary:99bee5627ff234eb0f31f5899628bff03df78b6d
+  circleci-docker-primary: &circleci-docker-primary trussworks/circleci-docker-primary:385c300cc218b910b6fd2da8041fe848001cecf4
 
 jobs:
   validate:


### PR DESCRIPTION
Trying to solve for this build failure by updating the docker image: https://app.circleci.com/pipelines/github/trussworks/ecs-service-logs/40/workflows/f7bf492b-3453-4831-85e8-c7df085cae58/jobs/47/steps