### PR TITLE
ci: updates renovate to use semver

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -4,15 +4,6 @@
   ],
   "packageRules": [
     {
-      "automerge": true,
-      "matchUpdateTypes": [
-        "patch",
-        "pin",
-        "digest",
-        "minor"
-      ]
-    },
-    {
       "description": "Tag the waddlers Github Team for major updates",
       "matchUpdateTypes": [
         "major"
@@ -25,16 +16,19 @@
       "automerge": true,
       "description": "Group minor and patch updates into a single PR",
       "groupName": "dependencies",
-      "managers": [
-        "terraform",
-        "pre-commit",
-        "gomod",
-        "dockerfile"
-      ],
+
       "matchUpdateTypes": [
         "minor",
-        "patch"
+        "patch",
+        "pin",
+        "digest"
       ]
+    },
+    {
+      "matchDatasources": [
+        "docker"
+      ],
+      "versioning": "semver"
     }
   ],
   "pre-commit": {

--- a/renovate.json
+++ b/renovate.json
@@ -16,7 +16,6 @@
       "automerge": true,
       "description": "Group minor and patch updates into a single PR",
       "groupName": "dependencies",
-
       "matchUpdateTypes": [
         "minor",
         "patch",


### PR DESCRIPTION
updates renovate to use semver for docker images also cleans up renovate a bit more
